### PR TITLE
Fixes out of gas errors by reactivating the solC optimzier

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -5,5 +5,17 @@ module.exports = {
       port: 8545,
       network_id: "*" // Match any network id
     }
+  },
+  solc: {
+    // Turns on the Solidity optimizer. For development the optimizer's
+    // quite helpful, just remember to be careful, and potentially turn it
+    // off, for live deployment and/or audit time. For more information,
+    // see the Truffle 4.0.0 release notes.
+    //
+    // https://github.com/trufflesuite/truffle/releases/tag/v4.0.0
+    optimizer: {
+      enabled: true,
+      runs: 200
+    }
   }
 };


### PR DESCRIPTION
Turns on the Solidity optimizer. For development the optimizer's quite helpful, just remember to be careful, and potentially turn it off, for live deployment and/or audit time. For more information, [see the Truffle 4.0.0 release notes](https://github.com/trufflesuite/truffle/releases/tag/v4.0.0).